### PR TITLE
fixes #8576 Cursor position is broken at v1.26.0

### DIFF
--- a/src/mode/modeHandler.ts
+++ b/src/mode/modeHandler.ts
@@ -1284,10 +1284,6 @@ export class ModeHandler implements vscode.Disposable, IModeHandler {
             }
             break;
 
-          case Mode.Insert:
-            // Don't collapse existing selections in insert mode
-            selections.push(new vscode.Selection(start, stop));
-            break;
           default:
             // Note that this collapses the selection onto one position
             selections.push(new vscode.Selection(stop, stop));


### PR DESCRIPTION
When the cursor moves in insert, there is no need to execute selection logic

**What this PR does / why we need it**:

This PR [Fix #7159 bad handling of auto-surrounding selections by Elliot-Roberts · Pull Request #8533 · VSCodeVim/Vim](https://github.com/VSCodeVim/Vim/pull/8533) introduces another new bug when solving a bug

For specific bug, please refer to [Cursor position with `Foldfix` enabled is broken as of `v1.26.0` update · Issue #8576 · VSCodeVim/Vim](https://github.com/VSCodeVim/Vim/issues/8576)

I located it here through debugging and also compared it with the previous version (without this bug)

Discovered that it was this code that caused it
 
**Which issue(s) this PR fixes**

[Cursor position with `Foldfix` enabled is broken as of `v1.26.0` update · Issue #8576 · VSCodeVim/Vim](https://github.com/VSCodeVim/Vim/issues/8576)

**Special notes for your reviewer**:
